### PR TITLE
Fixes Database.Escape() function doing weird things

### DIFF
--- a/Game Server/addons/sourcemod/scripting/levels_ranks/custom_functions.sp
+++ b/Game Server/addons/sourcemod/scripting/levels_ranks/custom_functions.sp
@@ -140,14 +140,14 @@ int GetMaxPlayers()
 
 char[] GetPlayerName(int iClient)
 {
-	static char sName[32];
-	static char sEscapedName[65];
+	static char sName[32], sEscapedName[65];
 
 	GetClientName(iClient, sName, sizeof(sName));
 
 	g_hDatabase.Escape(sName, sEscapedName, sizeof(sEscapedName));
 
-	if (!g_Settings[LR_DB_Allow_UTF8MB4]) {
+	if (!g_Settings[LR_DB_Allow_UTF8MB4])
+	{
 		GetFixNamePlayer(sEscapedName);
 	}
 

--- a/Game Server/addons/sourcemod/scripting/levels_ranks/custom_functions.sp
+++ b/Game Server/addons/sourcemod/scripting/levels_ranks/custom_functions.sp
@@ -140,18 +140,18 @@ int GetMaxPlayers()
 
 char[] GetPlayerName(int iClient)
 {
-	static char sName[65];
+	static char sName[32];
+	static char sEscapedName[65];
 
-	GetClientName(iClient, sName, 32);
+	GetClientName(iClient, sName, sizeof(sName));
 
-	g_hDatabase.Escape(sName, sName, sizeof(sName));
+	g_hDatabase.Escape(sName, sEscapedName, sizeof(sEscapedName));
 
-	if(!g_Settings[LR_DB_Allow_UTF8MB4])
-	{
-		GetFixNamePlayer(sName);
+	if (!g_Settings[LR_DB_Allow_UTF8MB4]) {
+		GetFixNamePlayer(sEscapedName);
 	}
 
-	return sName;
+	return sEscapedName;
 }
 
 /**


### PR DESCRIPTION
This PR fixes weird result of Database.Escape() function on players names which contains quotes.

Explanation: Using the same buffer as source and destination into Database.Escape() function will output an unexpected result. So I used two variables instead of reusing the same.

For more information you can see this post : https://forums.alliedmods.net/showthread.php?t=324069
